### PR TITLE
#22 [user] entity 생년월일 컬럼이 빠져서 다시 추가함

### DIFF
--- a/src/main/java/com/sparta/ticketauction/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/ticketauction/domain/user/entity/User.java
@@ -1,5 +1,7 @@
 package com.sparta.ticketauction.domain.user.entity;
 
+import java.time.LocalDate;
+
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Comment;
 
@@ -41,6 +43,10 @@ public class User {
 	@Comment("회원 전화번호")
 	@Column(name = "phone_number", length = 30)
 	private String phoneNumber;
+
+	@Comment("회원 생년월일")
+	@Column(name = "birth")
+	private LocalDate birth;
 
 	@Comment("회원 역할(관리자 or 일반 유저)")
 	@Column(name = "role")

--- a/src/main/java/com/sparta/ticketauction/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/ticketauction/domain/user/entity/User.java
@@ -9,6 +9,8 @@ import com.sparta.ticketauction.domain.user.entity.constant.Role;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -50,6 +52,7 @@ public class User {
 
 	@Comment("회원 역할(관리자 or 일반 유저)")
 	@Column(name = "role")
+	@Enumerated(EnumType.STRING)
 	private Role role = Role.USER;
 
 	@Comment("회원 보유 포인트")

--- a/src/main/java/com/sparta/ticketauction/domain/user/request/UserCreateRequest.java
+++ b/src/main/java/com/sparta/ticketauction/domain/user/request/UserCreateRequest.java
@@ -39,6 +39,6 @@ public class UserCreateRequest {
 	private final String phoneNumber;
 
 	@NotBlank(message = "필수 입력입니다.")
-	@JsonFormat(pattern = "yyyy-MM-dd")
+	@JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	private final LocalDate birth;
 }


### PR DESCRIPTION
## 개요 📝
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

유저 엔티티 내에서 생년월일이 빠짐을 확인 후 추가
request 내에서 birth 에 timezone 설정

<!---- Resolves: #(Isuue Number) -->

## PR 유형 ✅
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

<br>

## 작업사항 🛠️
<br>

## 변경로직 ⚠️ 
<br>

### 변경전
<br>

### 변경후
<br>

## 기타
(체크 해야하는 부분, jsonFormat 형식에 맞지 않는 경우에 어떻게 되는지 확인하쟈! 아자아자)
