### PR TITLE
#14 [auction] 입찰하기 기능 구현

### DIFF
--- a/src/main/java/com/sparta/ticketauction/domain/auction/constant/AuctionConstant.java
+++ b/src/main/java/com/sparta/ticketauction/domain/auction/constant/AuctionConstant.java
@@ -1,0 +1,6 @@
+package com.sparta.ticketauction.domain.auction.constant;
+
+public class AuctionConstant {
+	public static final double BID_PRICE_INCREASE_PERCENT = 0.5;
+	public static final String AUCTION_BID_KEY_PREFIX = "auctions_bid_";
+}

--- a/src/main/java/com/sparta/ticketauction/domain/auction/controller/BidController.java
+++ b/src/main/java/com/sparta/ticketauction/domain/auction/controller/BidController.java
@@ -1,4 +1,39 @@
 package com.sparta.ticketauction.domain.auction.controller;
 
+import static com.sparta.ticketauction.global.response.SuccessCode.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sparta.ticketauction.domain.auction.request.BidRequest;
+import com.sparta.ticketauction.domain.auction.service.BidService;
+import com.sparta.ticketauction.domain.user.entity.User;
+import com.sparta.ticketauction.global.annotaion.CurrentUser;
+import com.sparta.ticketauction.global.dto.EmptyObject;
+import com.sparta.ticketauction.global.response.ApiResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auctions/{auctionId}/bids")
+@RestController
 public class BidController {
+	private final BidService bidService;
+
+	/*입찰하기*/
+	@PostMapping
+	public ResponseEntity<ApiResponse<EmptyObject>> bid(
+		@PathVariable Long auctionId,
+		@Valid @RequestBody BidRequest bidRequest,
+		@CurrentUser User loginUser
+	) {
+		bidService.bid(auctionId, bidRequest, loginUser);
+		return ResponseEntity.status(SUCCESS_BID.getHttpStatus())
+			.body(ApiResponse.of(SUCCESS_BID.getCode(), SUCCESS_BID.getMessage()));
+	}
 }

--- a/src/main/java/com/sparta/ticketauction/domain/auction/repository/AuctionRedissonRepository.java
+++ b/src/main/java/com/sparta/ticketauction/domain/auction/repository/AuctionRedissonRepository.java
@@ -37,7 +37,7 @@ public class AuctionRedissonRepository {
 		return redissonClient.getBucket(key, codec);
 	}
 
-	public boolean existBucket(String key) {
-		return getBucket(key).isExists();
+	public boolean isExpired(String key) {
+		return getBucket(key).remainTimeToLive() < 1;
 	}
 }

--- a/src/main/java/com/sparta/ticketauction/domain/auction/repository/AuctionRedissonRepository.java
+++ b/src/main/java/com/sparta/ticketauction/domain/auction/repository/AuctionRedissonRepository.java
@@ -1,0 +1,43 @@
+package com.sparta.ticketauction.domain.auction.repository;
+
+import java.time.Duration;
+
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.Codec;
+import org.redisson.codec.TypedJsonJacksonCodec;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class AuctionRedissonRepository {
+	private final Codec codec = new TypedJsonJacksonCodec(Long.class);
+	private final RedissonClient redissonClient;
+
+	public void save(String key, Long value, long seconds) {
+		RBucket<Long> bucket = getBucket(key);
+		bucket.set(value);
+		bucket.expire(Duration.ofSeconds(seconds));
+	}
+
+	public Long getValue(String key) {
+		RBucket<Long> bucket = getBucket(key);
+		return bucket.get();
+	}
+
+	public void setValue(String key, Long value) {
+		RBucket<Long> bucket = getBucket(key);
+		long remainTtl = bucket.remainTimeToLive();
+		bucket.setIfExists(value, Duration.ofMillis(remainTtl));
+	}
+
+	public RBucket<Long> getBucket(String key) {
+		return redissonClient.getBucket(key, codec);
+	}
+
+	public boolean existBucket(String key) {
+		return getBucket(key).isExists();
+	}
+}

--- a/src/main/java/com/sparta/ticketauction/domain/auction/service/BidService.java
+++ b/src/main/java/com/sparta/ticketauction/domain/auction/service/BidService.java
@@ -1,4 +1,16 @@
 package com.sparta.ticketauction.domain.auction.service;
 
+import com.sparta.ticketauction.domain.auction.request.BidRequest;
+import com.sparta.ticketauction.domain.user.entity.User;
+
 public interface BidService {
+	/**
+	 * 입찰하기 기능
+	 * 경매에 입찰하는 기능
+	 *
+	 * @param auctionId  - 경매 식별자 ID
+	 * @param bidRequest - 입찰 요청 DTO
+	 * @param loginUser - 인증된 로그인 유저
+	 */
+	void bid(Long auctionId, BidRequest bidRequest, User loginUser);
 }

--- a/src/main/java/com/sparta/ticketauction/domain/auction/service/BidServiceImpl.java
+++ b/src/main/java/com/sparta/ticketauction/domain/auction/service/BidServiceImpl.java
@@ -63,7 +63,12 @@ public class BidServiceImpl implements BidService {
 	}
 
 	private static void validateBid(long point, long increaseBidPrice, long bidPrice) {
-		if (increaseBidPrice > bidPrice && point >= bidPrice) {
+		if (increaseBidPrice > bidPrice) {
+			throw new ApiException(BAD_REQUEST_BID);
+		}
+
+		//포인트가 부족한 경우
+		if (point < bidPrice) {
 			throw new ApiException(BAD_REQUEST_BID);
 		}
 	}

--- a/src/main/java/com/sparta/ticketauction/domain/auction/service/BidServiceImpl.java
+++ b/src/main/java/com/sparta/ticketauction/domain/auction/service/BidServiceImpl.java
@@ -3,16 +3,18 @@ package com.sparta.ticketauction.domain.auction.service;
 import static com.sparta.ticketauction.domain.auction.constant.AuctionConstant.*;
 import static com.sparta.ticketauction.global.exception.ErrorCode.*;
 
-import org.redisson.api.RAtomicLong;
-import org.redisson.api.RedissonClient;
+import java.time.Duration;
+
 import org.springframework.stereotype.Service;
 
 import com.sparta.ticketauction.domain.auction.entity.Auction;
 import com.sparta.ticketauction.domain.auction.entity.Bid;
+import com.sparta.ticketauction.domain.auction.repository.AuctionRedissonRepository;
 import com.sparta.ticketauction.domain.auction.repository.AuctionRepository;
 import com.sparta.ticketauction.domain.auction.repository.BidRepository;
 import com.sparta.ticketauction.domain.auction.request.BidRequest;
 import com.sparta.ticketauction.domain.user.entity.User;
+import com.sparta.ticketauction.domain.user.repository.UserRepository;
 import com.sparta.ticketauction.global.annotaion.DistributedLock;
 import com.sparta.ticketauction.global.exception.ApiException;
 
@@ -25,30 +27,32 @@ import lombok.extern.slf4j.Slf4j;
 public class BidServiceImpl implements BidService {
 
 	private final AuctionRepository auctionRepository;
+	private final UserRepository userRepository;
 	private final BidRepository bidRepository;
-	private final RedissonClient redissonClient;
+	private final AuctionRedissonRepository redissonRepository;
 
 	@Override
 	@DistributedLock(key = "T(com.sparta.ticketauction.domain.auction.constant.AuctionConstant).AUCTION_BID_KEY_PREFIX.concat(#auctionId)")
 	public void bid(Long auctionId, BidRequest bidRequest, User loginUser) {
 		String key = AUCTION_BID_KEY_PREFIX + auctionId;
-		RAtomicLong currentBid = redissonClient.getAtomicLong(key);
 
-		if (currentBid.remainTimeToLive() < 1) {
+		if (!redissonRepository.existBucket(key)) {
 			throw new ApiException(ENDED_AUCTION);
 		}
 
-		Auction auction = auctionRepository.getReferenceById(auctionId);
-		long currentBidPrice = redissonClient.getAtomicLong(key).get();
+		long currentBidPrice = redissonRepository.getValue(key);
 		long increaseBidPrice = (long)(currentBidPrice * BID_PRICE_INCREASE_PERCENT);
 		long bidPrice = bidRequest.getPrice();
 
-		if (increaseBidPrice > bidPrice) {
-			throw new ApiException(BAD_REQUEST_BID);
-		}
+		//상회입찰이 아니거나, 포인트가 입찰가보다 적은경우
+		long point = userRepository.findPointById(loginUser.getId());
+
+		validateBid(point, increaseBidPrice, bidPrice);
 
 		//경매 엔티티 입찰가 갱신 및 입찰 테이블 save
+		Auction auction = auctionRepository.getReferenceById(auctionId);
 		auction.updateBidPrice(bidPrice);
+
 		Bid bid = Bid.builder()
 			.price(bidPrice)
 			.user(loginUser)
@@ -56,6 +60,12 @@ public class BidServiceImpl implements BidService {
 			.build();
 
 		bidRepository.save(bid);
-		currentBid.set(bidPrice);
+		redissonRepository.setValue(key, bidPrice);
+	}
+
+	private static void validateBid(long point, long increaseBidPrice, long bidPrice) {
+		if (increaseBidPrice > bidPrice && point >= bidPrice) {
+			throw new ApiException(BAD_REQUEST_BID);
+		}
 	}
 }

--- a/src/main/java/com/sparta/ticketauction/domain/auction/service/BidServiceImpl.java
+++ b/src/main/java/com/sparta/ticketauction/domain/auction/service/BidServiceImpl.java
@@ -1,4 +1,61 @@
 package com.sparta.ticketauction.domain.auction.service;
 
+import static com.sparta.ticketauction.domain.auction.constant.AuctionConstant.*;
+import static com.sparta.ticketauction.global.exception.ErrorCode.*;
+
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+import com.sparta.ticketauction.domain.auction.entity.Auction;
+import com.sparta.ticketauction.domain.auction.entity.Bid;
+import com.sparta.ticketauction.domain.auction.repository.AuctionRepository;
+import com.sparta.ticketauction.domain.auction.repository.BidRepository;
+import com.sparta.ticketauction.domain.auction.request.BidRequest;
+import com.sparta.ticketauction.domain.user.entity.User;
+import com.sparta.ticketauction.global.annotaion.DistributedLock;
+import com.sparta.ticketauction.global.exception.ApiException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
 public class BidServiceImpl implements BidService {
+
+	private final AuctionRepository auctionRepository;
+	private final BidRepository bidRepository;
+	private final RedissonClient redissonClient;
+
+	@Override
+	@DistributedLock(key = "T(com.sparta.ticketauction.domain.auction.constant.AuctionConstant).AUCTION_BID_KEY_PREFIX.concat(#auctionId)")
+	public void bid(Long auctionId, BidRequest bidRequest, User loginUser) {
+		String key = AUCTION_BID_KEY_PREFIX + auctionId;
+		RAtomicLong currentBid = redissonClient.getAtomicLong(key);
+
+		if (currentBid.remainTimeToLive() < 1) {
+			throw new ApiException(ENDED_AUCTION);
+		}
+
+		Auction auction = auctionRepository.getReferenceById(auctionId);
+		long currentBidPrice = redissonClient.getAtomicLong(key).get();
+		long increaseBidPrice = (long)(currentBidPrice * BID_PRICE_INCREASE_PERCENT);
+		long bidPrice = bidRequest.getPrice();
+
+		if (increaseBidPrice > bidPrice) {
+			throw new ApiException(BAD_REQUEST_BID);
+		}
+
+		//경매 엔티티 입찰가 갱신 및 입찰 테이블 save
+		auction.updateBidPrice(bidPrice);
+		Bid bid = Bid.builder()
+			.price(bidPrice)
+			.user(loginUser)
+			.auction(auction)
+			.build();
+
+		bidRepository.save(bid);
+		currentBid.set(bidPrice);
+	}
 }

--- a/src/main/java/com/sparta/ticketauction/domain/auction/service/BidServiceImpl.java
+++ b/src/main/java/com/sparta/ticketauction/domain/auction/service/BidServiceImpl.java
@@ -3,8 +3,6 @@ package com.sparta.ticketauction.domain.auction.service;
 import static com.sparta.ticketauction.domain.auction.constant.AuctionConstant.*;
 import static com.sparta.ticketauction.global.exception.ErrorCode.*;
 
-import java.time.Duration;
-
 import org.springframework.stereotype.Service;
 
 import com.sparta.ticketauction.domain.auction.entity.Auction;
@@ -60,6 +58,7 @@ public class BidServiceImpl implements BidService {
 			.build();
 
 		bidRepository.save(bid);
+		loginUser.deductPoint(bidPrice);
 		redissonRepository.setValue(key, bidPrice);
 	}
 

--- a/src/main/java/com/sparta/ticketauction/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/ticketauction/domain/user/repository/UserRepository.java
@@ -3,6 +3,8 @@ package com.sparta.ticketauction.domain.user.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.sparta.ticketauction.domain.user.entity.User;
 
@@ -14,4 +16,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findByEmail(String email);
 
+	// id를 사용하여 point 조회
+	@Query("SELECT u.point FROM User u WHERE u.id = :userId")
+	Long findPointById(@Param("userId") Long userId);
 }

--- a/src/main/java/com/sparta/ticketauction/global/annotaion/DistributedLock.java
+++ b/src/main/java/com/sparta/ticketauction/global/annotaion/DistributedLock.java
@@ -24,11 +24,11 @@ public @interface DistributedLock {
 	 * 락을 기다리는 시간 (default - 5s)
 	 * 락 획득을 위해 waitTime 만큼 대기한다
 	 */
-	long waitTime() default 3L;
+	long waitTime() default 8L;
 
 	/**
 	 * 락 임대 시간 (default - 3s)
 	 * 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
 	 */
-	long leaseTime() default 2L;
+	long leaseTime() default 6L;
 }

--- a/src/main/java/com/sparta/ticketauction/global/aop/AopForTransaction.java
+++ b/src/main/java/com/sparta/ticketauction/global/aop/AopForTransaction.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class AopForTransaction {
 
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional(propagation = Propagation.REQUIRES_NEW, timeout = 5)
 	public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
 		return joinPoint.proceed();
 	}

--- a/src/main/java/com/sparta/ticketauction/global/aop/DistributedLockAop.java
+++ b/src/main/java/com/sparta/ticketauction/global/aop/DistributedLockAop.java
@@ -53,11 +53,13 @@ public class DistributedLockAop {
 		} catch (InterruptedException e) {
 			throw new InterruptedException();
 		} finally {
-			rLock.unlock();
-
-			log.debug("Redisson UnLock");
-			log.debug("serviceName: {}", method.getName());
-			log.debug("key: {}", key);
+			try {
+				rLock.unlock();
+			} catch (IllegalMonitorStateException e) {
+				log.debug("Redisson Already UnLock");
+				log.debug("serviceName: {}", method.getName());
+				log.debug("key: {}", key);
+			}
 		}
 	}
 }

--- a/src/main/java/com/sparta/ticketauction/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/ticketauction/global/exception/ErrorCode.java
@@ -42,7 +42,9 @@ public enum ErrorCode {
 
 
 	/* AUCTION */
-
+	NOT_FOUND_AUCTION(HttpStatus.NOT_FOUND, "", "해당하는 경매를 찾지 못했습니다."),
+	ENDED_AUCTION(HttpStatus.BAD_REQUEST, "", "경매가 종료되었습니다."),
+	BAD_REQUEST_BID(HttpStatus.BAD_REQUEST, "", "현재 입찰가보다 5% 이상이어야합니다."),
 
 
 

--- a/src/main/java/com/sparta/ticketauction/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/ticketauction/global/exception/ErrorCode.java
@@ -42,9 +42,9 @@ public enum ErrorCode {
 
 
 	/* AUCTION */
-	NOT_FOUND_AUCTION(HttpStatus.NOT_FOUND, "", "해당하는 경매를 찾지 못했습니다."),
-	ENDED_AUCTION(HttpStatus.BAD_REQUEST, "", "경매가 종료되었습니다."),
-	BAD_REQUEST_BID(HttpStatus.BAD_REQUEST, "", "현재 입찰가보다 5% 이상이어야합니다."),
+	NOT_FOUND_AUCTION(HttpStatus.NOT_FOUND, "A10000", "해당하는 경매를 찾지 못했습니다."),
+	ENDED_AUCTION(HttpStatus.BAD_REQUEST, "A10001", "경매가 종료되었습니다."),
+	BAD_REQUEST_BID(HttpStatus.BAD_REQUEST, "A10100", "현재 입찰가보다 5% 이상이어야합니다."),
 
 
 

--- a/src/main/java/com/sparta/ticketauction/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/ticketauction/global/exception/ErrorCode.java
@@ -58,7 +58,7 @@ public enum ErrorCode {
 	INVALID_SEAT_PRICE(HttpStatus.BAD_REQUEST, "R10001", "좌석 가격이 올바르지 않습니다."),
 
 	/* PAYMENT */
-	NOT_ENOUGH_POINT(HttpStatus.OK, "", "결제할 포인트가 부족합니다"),
+	NOT_ENOUGH_POINT(HttpStatus.BAD_REQUEST, "", "결제할 포인트가 부족합니다"),
 
 	/* GLOBAL */
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "", ""),

--- a/src/main/java/com/sparta/ticketauction/global/response/SuccessCode.java
+++ b/src/main/java/com/sparta/ticketauction/global/response/SuccessCode.java
@@ -41,7 +41,7 @@ public enum SuccessCode {
 
 
 	/* AUCTION */
-
+	SUCCESS_BID(HttpStatus.CREATED, "A00100", "입찰에 성공했습니다."),
 
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,12 @@ spring:
     username: ${db_username}
     password: ${db_password}
     url: jdbc:mysql://localhost:3306/ticket_auction
+    hikari :
+      connection-timeout: 3000
+      validation-timeout: 3000
+      minimum-idle: 10
+      max-lifetime: 240000
+      maximum-pool-size: 20
   jpa:
     hibernate:
       ddl-auto: none

--- a/src/test/java/com/sparta/ticketauction/domain/auction/service/BidServiceTest.java
+++ b/src/test/java/com/sparta/ticketauction/domain/auction/service/BidServiceTest.java
@@ -59,8 +59,8 @@ class BidServiceTest {
 			.startPrice(1000L)
 			.build();
 
-		given(redissonRepository.existBucket(any()))
-			.willReturn(true);
+		given(redissonRepository.isExpired(any()))
+			.willReturn(false);
 
 		given(redissonRepository.getValue(any()))
 			.willReturn(1000L);
@@ -84,8 +84,8 @@ class BidServiceTest {
 		Long auctionId = 1L;
 		BidRequest bidRequest = new BidRequest(10_000L);
 
-		given(redissonRepository.existBucket(any()))
-			.willReturn(true);
+		given(redissonRepository.isExpired(any()))
+			.willReturn(false);
 
 		given(redissonRepository.getValue(any()))
 			.willReturn(1000_000L);
@@ -105,8 +105,8 @@ class BidServiceTest {
 		BidRequest bidRequest = new BidRequest(10_0000L);
 
 
-		given(redissonRepository.existBucket(any()))
-			.willReturn(false);
+		given(redissonRepository.isExpired(any()))
+			.willReturn(true);
 
 		//When & Then
 		assertThatThrownBy(() -> sut.bid(auctionId, bidRequest, UserUtil.createUser()))

--- a/src/test/java/com/sparta/ticketauction/domain/auction/service/BidServiceTest.java
+++ b/src/test/java/com/sparta/ticketauction/domain/auction/service/BidServiceTest.java
@@ -30,13 +30,6 @@ import com.sparta.ticketauction.global.exception.ErrorCode;
 @DisplayName("[경매] 서비스 테스트")
 @ExtendWith(MockitoExtension.class)
 class BidServiceTest {
-	private static final String EMAIL = "tester@gmail.com";
-	private static final String PASSWORD = "test123!@#";
-	private static final String NAME = "김수한";
-	private static final String NICKNAME = "두루미";
-	private static final String PHONE_NUMBER = "010-1234-5678";
-	private static final LocalDate BIRTH = LocalDate.of(1990, 1, 1);
-
 	@InjectMocks
 	private BidServiceImpl sut;
 

--- a/src/test/java/com/sparta/ticketauction/domain/auction/service/BidServiceTest.java
+++ b/src/test/java/com/sparta/ticketauction/domain/auction/service/BidServiceTest.java
@@ -1,0 +1,120 @@
+package com.sparta.ticketauction.domain.auction.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.sparta.ticketauction.domain.auction.entity.Auction;
+import com.sparta.ticketauction.domain.auction.entity.Bid;
+import com.sparta.ticketauction.domain.auction.repository.AuctionRepository;
+import com.sparta.ticketauction.domain.auction.repository.BidRepository;
+import com.sparta.ticketauction.domain.auction.request.BidRequest;
+import com.sparta.ticketauction.domain.user.util.UserUtil;
+import com.sparta.ticketauction.global.exception.ApiException;
+import com.sparta.ticketauction.global.exception.ErrorCode;
+
+@DisplayName("[경매] 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class BidServiceTest {
+	private static final String EMAIL = "tester@gmail.com";
+	private static final String PASSWORD = "test123!@#";
+	private static final String NAME = "김수한";
+	private static final String NICKNAME = "두루미";
+	private static final String PHONE_NUMBER = "010-1234-5678";
+	private static final LocalDate BIRTH = LocalDate.of(1990, 1, 1);
+
+	@InjectMocks
+	private BidServiceImpl sut;
+
+	@Mock
+	private AuctionRepository auctionRepository;
+
+	@Mock
+	private BidRepository bidRepository;
+
+	@Mock
+	private RedissonClient redissonClient;
+
+
+
+	//로그인한 유저가
+	//특정 경매에 입찰금액을 적고 입찰하기 버튼을 눌렀을때.
+	//해당 경매에 대한 입찰 기록을 저장하고
+	//경매의 현재가 최신화를 해줘야함.
+	@Test
+	void 입찰하기_정상_테스트() throws Exception {
+		//Given
+		Long auctionId = 1L;
+		BidRequest bidRequest = new BidRequest(10_0000L);
+		Auction auction = Auction.builder()
+			.startDateTime(LocalDateTime.now())
+			.endDateTime(LocalDateTime.now().plusDays(7))
+			.startPrice(1000L)
+			.build();
+
+		RAtomicLong atomicLong = mock(RAtomicLong.class);
+		given(redissonClient.getAtomicLong(any()))
+			.willReturn(atomicLong);
+
+		given(auctionRepository.getReferenceById(auctionId))
+			.willReturn(auction);
+		//When
+		sut.bid(auctionId, bidRequest, UserUtil.createUser());
+
+		//Then
+		then(bidRepository).should().save(any(Bid.class));
+		then(atomicLong).should().set(bidRequest.getPrice());
+	}
+
+	@Test
+	void 입찰하기_하회입찰_실패_테스트() throws Exception {
+		//Given
+		Long auctionId = 1L;
+		BidRequest bidRequest = new BidRequest(10_000L);
+
+		RAtomicLong atomicLong = mock(RAtomicLong.class);
+		given(redissonClient.getAtomicLong(any()))
+			.willReturn(atomicLong);
+
+		given(atomicLong.get())
+			.willReturn(1000_000L);
+
+		//When & Then
+		assertThatThrownBy(() -> sut.bid(auctionId, bidRequest, UserUtil.createUser()))
+			.isInstanceOf(ApiException.class)
+			.hasMessage(ErrorCode.BAD_REQUEST_BID.getMessage());
+	}
+
+	@Test
+	void 입찰하기_경매종료_테스트() throws Exception {
+		//Given
+		Long auctionId = 1L;
+		BidRequest bidRequest = new BidRequest(10_0000L);
+
+		RAtomicLong atomicLong = mock(RAtomicLong.class);
+		given(redissonClient.getAtomicLong(any()))
+			.willReturn(atomicLong);
+
+		given(atomicLong.remainTimeToLive())
+			.willReturn(0L);
+
+		//When & Then
+		assertThatThrownBy(() -> sut.bid(auctionId, bidRequest, UserUtil.createUser()))
+			.isInstanceOf(ApiException.class)
+			.hasMessage(ErrorCode.ENDED_AUCTION.getMessage());
+	}
+}


### PR DESCRIPTION
 - 5% 이상 상회입찰가면 DB저장 후 Redis에  입찰가 갱신 => 추후 DB 저장도 비동기로 처리하면 더 좋을 것 같음

- Redisson 자료구조에 값을 저장할 때, 클래스 타입 정보를 같이 저장함.
 값만 저장하기 위해서는 codec에 타입 정보클래스를 초기화 하고 해당 코덱을
 세팅해줘야함
 입찰관련 redisson repository class 를 만들어 사용하기로 변경
 추후 리팩토링 여지가 많음

 - 요청한 입찰가에 대해 포인트 검증 및 차감 추가
 
 - ToDo: 
    - 일정 여유되면 알림기능도 연동
    - redisson repository 리팩토링
    - 입찰가 포인트 차감 리팩토링
   
## 개요 📝
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->
Resolves: #14 

## PR 유형 ✅
어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

<br>

## 작업사항 🛠️
<br>

## 변경로직 ⚠️ 
<br>

### 변경전
<br>

### 변경후
<br>

## 기타
